### PR TITLE
Update Order Status Mappings and Minor Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ This project is licensed under the Apache 2.0 License
 
 ## Changelog
 
+## 1.4
+
+- Declare HPOS Compatibility
+- Remove deprecated Charge status mappings
+- Fix order_id incorrect format error
+- Update coinbase_charge_id to be charge.id
+
 ## 1.3
 
 - Adds HPOS support

--- a/class-wc-gateway-coinbase.php
+++ b/class-wc-gateway-coinbase.php
@@ -327,7 +327,7 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 				exit;
 			}
 
-			$order_id = $event_data['metadata']['order_id'];
+			$order_id = intval($event_data['metadata']['order_id']);
 
 			$this->_update_order_status( wc_get_order( $order_id ), $event_data['timeline'] );
 

--- a/class-wc-gateway-coinbase.php
+++ b/class-wc-gateway-coinbase.php
@@ -390,19 +390,8 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 				$order->update_status( 'cancelled', __( 'Coinbase payment expired.', 'coinbase' ) );
 			} elseif ( 'CANCELED' === $status ) {
 				$order->update_status( 'cancelled', __( 'Coinbase payment cancelled.', 'coinbase' ) );
-			} elseif ( 'UNRESOLVED' === $status ) {
-				if ('OVERPAID' === $last_update['context']) {
-					$order->update_status( 'processing', __( 'Coinbase payment was successfully processed.', 'coinbase' ) );
-					$order->payment_complete();
-				} else {
-					// translators: Coinbase error status for "unresolved" payment. Includes error status.
-					$order->update_status( 'failed', sprintf( __( 'Coinbase payment unresolved, reason: %s.', 'coinbase' ), $last_update['context'] ) );
-				}
 			} elseif ( 'PENDING' === $status ) {
 				$order->update_status( 'blockchainpending', __( 'Coinbase payment detected, but awaiting blockchain confirmation.', 'coinbase' ) );
-			} elseif ( 'RESOLVED' === $status ) {
-				// We don't know the resolution, so don't change order status.
-				$order->add_order_note( __( 'Coinbase payment marked as resolved.', 'coinbase' ) );
 			} elseif ( 'COMPLETED' === $status ) {
 				$order->update_status( 'processing', __( 'Coinbase payment was successfully processed.', 'coinbase' ) );
 				$order->payment_complete();
@@ -410,7 +399,7 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 		}
 
 		// Archive if in a resolved state and idle more than timeout.
-		if ( in_array( $status, array( 'EXPIRED', 'COMPLETED', 'RESOLVED' ), true ) &&
+		if ( in_array( $status, array( 'EXPIRED', 'COMPLETED' ), true ) &&
 			$order->get_date_modified() < $this->timeout ) {
 			self::log( 'Archiving order: ' . $order->get_order_number() );
 			$order->update_meta_data( '_coinbase_archived', true );

--- a/class-wc-gateway-coinbase.php
+++ b/class-wc-gateway-coinbase.php
@@ -241,7 +241,7 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 
 		$charge = $result[1]['data'];
 
-		$order->update_meta_data( '_coinbase_charge_id', $charge['code'] );
+		$order->update_meta_data( '_coinbase_charge_id', $charge['id'] );
 		$order->save();
 
 		return array(

--- a/coinbase-commerce.php
+++ b/coinbase-commerce.php
@@ -3,7 +3,7 @@
 Plugin Name:  Coinbase Commerce
 Plugin URI:   https://github.com/coinbase/coinbase-commerce-woocommerce/
 Description:  A payment gateway that allows your customers to pay with cryptocurrency via Coinbase Commerce (https://commerce.coinbase.com/)
-Version:      1.3
+Version:      1.4
 Author:       Coinbase Commerce
 Author URI:   https://commerce.coinbase.com/
 License:      GPLv3+

--- a/coinbase-commerce.php
+++ b/coinbase-commerce.php
@@ -47,6 +47,11 @@ function cb_init_gateway() {
 		add_filter( 'woocommerce_email_order_meta_fields', 'cb_custom_woocommerce_email_order_meta_fields', 10, 3 );
 		add_filter( 'woocommerce_email_actions', 'cb_register_email_action' );
 		add_action( 'woocommerce_email', 'cb_add_email_triggers' );
+		add_action( 'before_woocommerce_init', function() {
+			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+			}
+		} );
 	}
 }
 add_action( 'plugins_loaded', 'cb_init_gateway' );

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: coinbase, woo, woocommerce, ecommerce, bitcoin, ethereum, litecoin, bitcas
 Requires at least: 3.0
 Requires PHP: 5.6+
 Tested up to: 6.0
-Stable tag: 1.3
+Stable tag: 1.4
 License: GPLv2 or later
 
 == Description ==
@@ -101,6 +101,12 @@ This plugin replaces the previous deprecated coinbase-woocommerce plugin.
 
 
 == Changelog ==
+
+= 1.4 =
+* Declare HPOS Compatibility
+* Remove deprecated Charge status mappings
+* Fix order_id incorrect format error
+* Update coinbase_charge_id to be charge.id
 
 = 1.3 =
 * Adds HPOS support


### PR DESCRIPTION
Bugs fixed:
- Declare HPOS Compatibility
- Remove deprecated Charge status mappings
- Fix order_id incorrect format error
- Update coinbase_charge_id to be charge.id