### PR TITLE
Update Tested Versions and Minor Copy/Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ This project is licensed under the Apache 2.0 License
 
 ## Changelog
 
+## 1.4.1
+
+- Tested against WordPress 6.5.3
+- Tested against WooCommerce 8.9.1
+
 ## 1.4
 
 - Declare HPOS Compatibility

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ If this is checked, these are saved within your `wp-content/uploads/wc-logs/` fo
 
 To use this plugin with your WooCommerce store you will need:
 
-- [WordPress] (tested up to 4.9.7)
-- [WooCommerce] (tested up to 3.4.3)
+- [WordPress] (tested up to 6.5.3)
+- [WooCommerce] (tested up to 8.9.1)
 
 ## Frequently Asked Questions
 

--- a/class-wc-gateway-coinbase.php
+++ b/class-wc-gateway-coinbase.php
@@ -225,7 +225,7 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 
 		// Create a new charge.
 		$metadata = array(
-			'order_id'  => $order->get_id(),
+			'order_id'  => strval($order->get_id()),
 			'order_key' => $order->get_order_key(),
 			'source' => 'woocommerce'
 		);
@@ -327,7 +327,7 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 				exit;
 			}
 
-			$order_id = intval($event_data['metadata']['order_id']);
+			$order_id = $event_data['metadata']['order_id'];
 
 			$this->_update_order_status( wc_get_order( $order_id ), $event_data['timeline'] );
 

--- a/class-wc-gateway-coinbase.php
+++ b/class-wc-gateway-coinbase.php
@@ -132,7 +132,7 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 				'title'       => __( 'Title', 'woocommerce' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
-				'default'     => __( 'Bitcoin and other cryptocurrencies', 'coinbase' ),
+				'default'     => __( 'Ethereum and other cryptocurrencies', 'coinbase' ),
 				'desc_tip'    => true,
 			),
 			'description'    => array(
@@ -140,7 +140,7 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 				'type'        => 'text',
 				'desc_tip'    => true,
 				'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce' ),
-				'default'     => __( 'Pay with Bitcoin or other cryptocurrencies.', 'coinbase' ),
+				'default'     => __( 'Pay with Ethereum or other cryptocurrencies.', 'coinbase' ),
 			),
 			'api_key'        => array(
 				'title'       => __( 'API Key', 'coinbase' ),

--- a/coinbase-commerce.php
+++ b/coinbase-commerce.php
@@ -12,7 +12,7 @@ Text Domain:  coinbase
 Domain Path:  /languages
 
 WC requires at least: 3.0.9
-WC tested up to: 6.5.1
+WC tested up to: 8.9.1
 
 Coinbase Commerce is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/coinbase-commerce.php
+++ b/coinbase-commerce.php
@@ -3,7 +3,7 @@
 Plugin Name:  Coinbase Commerce
 Plugin URI:   https://github.com/coinbase/coinbase-commerce-woocommerce/
 Description:  A payment gateway that allows your customers to pay with cryptocurrency via Coinbase Commerce (https://commerce.coinbase.com/)
-Version:      1.4
+Version:      1.4.1
 Author:       Coinbase Commerce
 Author URI:   https://commerce.coinbase.com/
 License:      GPLv3+

--- a/readme.txt
+++ b/readme.txt
@@ -1,16 +1,16 @@
 === Coinbase Commerce Payment Gateway for WooCommerce ===
 Contributors: pragbarrett, eddhurst, omidahourai, robbybarton
 Plugin URL: https://commerce.coinbase.com/
-Tags: coinbase, woo, woocommerce, ecommerce, bitcoin, ethereum, litecoin, bitcash, blockchain, commerce, crypto, cryptocurrency
+Tags: coinbase, woocommerce, ethereum, commerce, crypto
 Requires at least: 3.0
-Requires PHP: 5.6+
-Tested up to: 6.0
+Requires PHP: 8.1+
+Tested up to: 6.5.3
 Stable tag: 1.4
 License: GPLv2 or later
 
 == Description ==
 
-Accept cryptocurrencies through Coinbase Commerce such as Bitcoin, Ethereum, Litecoin and Bitcoin Cash on your WooCommerce store.
+Accept cryptocurrencies through Coinbase Commerce such as Ethereum, Litecoin and Bitcoin Cash on your WooCommerce store.
 
 == Installation ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -10,7 +10,7 @@ License: GPLv2 or later
 
 == Description ==
 
-Accept cryptocurrencies through Coinbase Commerce such as Ethereum, Litecoin and Bitcoin Cash on your WooCommerce store.
+Accept cryptocurrencies through Coinbase Commerce such as USDC, Ethereum, and Matic on your WooCommerce store.
 
 == Installation ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,10 @@ This plugin replaces the previous deprecated coinbase-woocommerce plugin.
 
 == Changelog ==
 
+= 1.4.1 =
+* Tested against WordPress 6.5.3
+* Tested against WooCommerce 8.9.1
+
 = 1.4 =
 * Declare HPOS Compatibility
 * Remove deprecated Charge status mappings


### PR DESCRIPTION
What changed? 
- Updated WP & WC tested up to versions
- Cast order_id metadata to string
- Minor copy updates and tagging