### PR TITLE
Add sandbox mode support for testing payments

### DIFF
--- a/class-wc-gateway-coinbase.php
+++ b/class-wc-gateway-coinbase.php
@@ -67,6 +67,10 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', array( $this, '_custom_query_var' ), 10, 2 );
 		add_action( 'woocommerce_api_wc_gateway_coinbase', array( $this, 'handle_webhook' ) );
+
+		if ( is_admin() ) {
+			add_action( 'admin_notices', array( $this, 'sandbox_mode_notice' ) );
+		}
 	}
 
 	/**
@@ -115,6 +119,13 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 				'type'    => 'checkbox',
 				'label'   => __( 'Enable Coinbase Business Payment', 'coinbase' ),
 				'default' => 'yes',
+			),
+			'sandbox_mode'    => array(
+				'title'       => __( 'Sandbox Mode', 'coinbase' ),
+				'type'        => 'checkbox',
+				'label'       => __( 'Enable Sandbox (Test) Mode', 'coinbase' ),
+				'default'     => 'no',
+				'description' => __( 'When enabled, payments use the Coinbase sandbox environment. No real funds are transferred.', 'coinbase' ),
 			),
 			'title'           => array(
 				'title'       => __( 'Title', 'woocommerce' ),
@@ -168,6 +179,11 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 
 				__( '3. Copy the webhook secret and paste it into the box above.', 'coinbase' ),
 
+			),
+			'sandbox_webhook_secret' => array(
+				'title'       => __( 'Sandbox Webhook Secret', 'coinbase' ),
+				'type'        => 'text',
+				'description' => __( 'Webhook secret for the sandbox environment. Create a separate webhook subscription with the sandbox label.', 'coinbase' ),
 			),
 			'show_icons'      => array(
 				'title'       => __( 'Show icons', 'coinbase' ),
@@ -380,7 +396,9 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 		}
 
 		$signature_header = $headers[ Coinbase_Constants::SIGNATURE_HEADER ];
-		$secret           = $this->get_option( 'webhook_secret' );
+		$secret           = 'yes' === $this->get_option( 'sandbox_mode' )
+			? $this->get_option( 'sandbox_webhook_secret' )
+			: $this->get_option( 'webhook_secret' );
 
 		// Parse the signature header (format: t=timestamp,v0=sig,h=headers,v1=sig)
 		$parts = array();
@@ -418,6 +436,21 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Display admin notice when sandbox mode is active.
+	 */
+	public function sandbox_mode_notice() {
+		if ( 'yes' !== $this->get_option( 'sandbox_mode' ) ) {
+			return;
+		}
+		echo '<div class="notice notice-warning"><p>';
+		printf(
+			__( '<strong>Coinbase Business:</strong> Sandbox mode is active. No real funds will be transferred. <a href="%s">Disable sandbox mode</a> when ready to accept live payments.', 'coinbase' ),
+			esc_url( admin_url( 'admin.php?page=wc-settings&tab=checkout&section=coinbase' ) )
+		);
+		echo '</p></div>';
+	}
+
+	/**
 	 * Init the API class and set credentials.
 	 */
 	protected function init_api() {
@@ -428,6 +461,7 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 		Coinbase_API_Handler::$log             = get_class( $this ) . '::log';
 		Coinbase_API_Handler::$cdp_key_name    = $this->get_option( 'cdp_key_name' );
 		Coinbase_API_Handler::$cdp_private_key = $this->get_option( 'cdp_private_key' );
+		Coinbase_API_Handler::$sandbox_mode    = 'yes' === $this->get_option( 'sandbox_mode' );
 	}
 
 	/**

--- a/includes/class-coinbase-api-handler.php
+++ b/includes/class-coinbase-api-handler.php
@@ -42,6 +42,22 @@ class Coinbase_API_Handler {
 	public static $cdp_private_key;
 
 	/**
+	 * Whether sandbox mode is enabled.
+	 *
+	 * @var bool
+	 */
+	public static $sandbox_mode = false;
+
+	/**
+	 * Get the API path based on sandbox mode.
+	 *
+	 * @return string
+	 */
+	public static function get_api_path() {
+		return self::$sandbox_mode ? Coinbase_Constants::SANDBOX_API_PATH : Coinbase_Constants::API_PATH;
+	}
+
+	/**
 	 * Get the response from an API request.
 	 *
 	 * @param  string $path   API path (e.g., /api/v1/payment-links).
@@ -134,7 +150,7 @@ class Coinbase_API_Handler {
 			$body['description'] = mb_substr( $description, 0, 500 );
 		}
 
-		return self::send_request( Coinbase_Constants::API_PATH, $body, 'POST' );
+		return self::send_request( self::get_api_path(), $body, 'POST' );
 	}
 
 	/**
@@ -144,7 +160,7 @@ class Coinbase_API_Handler {
 	 * @return array  [bool $success, mixed $data]
 	 */
 	public static function get_payment_link( $id ) {
-		$path = Coinbase_Constants::API_PATH . '/' . $id;
+		$path = self::get_api_path() . '/' . $id;
 		return self::send_request( $path );
 	}
 }

--- a/includes/class-coinbase-constants.php
+++ b/includes/class-coinbase-constants.php
@@ -10,7 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Coinbase_Constants {
 
 	const API_BASE_URL = 'https://business.coinbase.com';
-	const API_PATH     = '/api/v1/payment-links';
+	const API_PATH         = '/api/v1/payment-links';
+	const SANDBOX_API_PATH = '/sandbox/api/v1/payment-links';
 
 	const JWT_ISSUER         = 'cdp';
 	const JWT_EXPIRY_SECONDS = 120;

--- a/tests/phpunit/test-wc-coinbase.php
+++ b/tests/phpunit/test-wc-coinbase.php
@@ -297,4 +297,86 @@ class WC_Coinbase_Test extends WP_UnitTestCase {
 			) ),
 		);
 	}
+
+	/**
+	 * Test that sandbox mode returns sandbox API path.
+	 */
+	public function test_sandbox_mode_uses_sandbox_api_path() {
+		$payment_gateway = WC()->payment_gateways->payment_gateways()['coinbase'];
+
+		$init_api = new ReflectionMethod( $payment_gateway, 'init_api' );
+		$init_api->setAccessible( true );
+		$init_api->invoke( $payment_gateway );
+
+		Coinbase_API_Handler::$sandbox_mode = true;
+		$this->assertSame( '/sandbox/api/v1/payment-links', Coinbase_API_Handler::get_api_path() );
+
+		// Clean up.
+		Coinbase_API_Handler::$sandbox_mode = false;
+	}
+
+	/**
+	 * Test that production mode returns production API path.
+	 */
+	public function test_production_mode_uses_production_api_path() {
+		$payment_gateway = WC()->payment_gateways->payment_gateways()['coinbase'];
+
+		$init_api = new ReflectionMethod( $payment_gateway, 'init_api' );
+		$init_api->setAccessible( true );
+		$init_api->invoke( $payment_gateway );
+
+		Coinbase_API_Handler::$sandbox_mode = false;
+		$this->assertSame( '/api/v1/payment-links', Coinbase_API_Handler::get_api_path() );
+	}
+
+	/**
+	 * Test webhook uses sandbox secret when sandbox mode is enabled.
+	 */
+	public function test_webhook_uses_sandbox_secret_in_sandbox_mode() {
+		$payment_gateway = WC()->payment_gateways->payment_gateways()['coinbase'];
+
+		$payment_gateway->update_option( 'sandbox_mode', 'yes' );
+		$payment_gateway->update_option( 'webhook_secret', 'production_secret' );
+		$payment_gateway->update_option( 'sandbox_webhook_secret', 'sandbox_secret' );
+
+		$payload   = '{"eventType":"payment_link.payment.success","metadata":{"order_id":"1"}}';
+		$timestamp = time();
+		$signature = hash_hmac( 'sha256', $timestamp . '.' . $payload, 'sandbox_secret' );
+
+		$_SERVER['HTTP_X_HOOK0_SIGNATURE'] = 't=' . $timestamp . ',v0=' . $signature;
+
+		include_once dirname( dirname( __DIR__ ) ) . '/includes/class-coinbase-constants.php';
+
+		$result = $payment_gateway->validate_webhook( $payload );
+		$this->assertTrue( $result );
+
+		// Clean up.
+		$payment_gateway->update_option( 'sandbox_mode', 'no' );
+		unset( $_SERVER['HTTP_X_HOOK0_SIGNATURE'] );
+	}
+
+	/**
+	 * Test webhook uses production secret when sandbox mode is disabled.
+	 */
+	public function test_webhook_uses_production_secret_in_production_mode() {
+		$payment_gateway = WC()->payment_gateways->payment_gateways()['coinbase'];
+
+		$payment_gateway->update_option( 'sandbox_mode', 'no' );
+		$payment_gateway->update_option( 'webhook_secret', 'production_secret' );
+		$payment_gateway->update_option( 'sandbox_webhook_secret', 'sandbox_secret' );
+
+		$payload   = '{"eventType":"payment_link.payment.success","metadata":{"order_id":"1"}}';
+		$timestamp = time();
+		$signature = hash_hmac( 'sha256', $timestamp . '.' . $payload, 'production_secret' );
+
+		$_SERVER['HTTP_X_HOOK0_SIGNATURE'] = 't=' . $timestamp . ',v0=' . $signature;
+
+		include_once dirname( dirname( __DIR__ ) ) . '/includes/class-coinbase-constants.php';
+
+		$result = $payment_gateway->validate_webhook( $payload );
+		$this->assertTrue( $result );
+
+		// Clean up.
+		unset( $_SERVER['HTTP_X_HOOK0_SIGNATURE'] );
+	}
 }


### PR DESCRIPTION
## Demo
https://github.com/user-attachments/assets/77a36f2d-8540-4132-a993-2ba167f91c3c

In settings:
<img width="945" height="79" alt="Screenshot 2026-03-10 at 3 51 10 PM" src="https://github.com/user-attachments/assets/8a982dcf-2c57-44ec-ab25-3194be5ace3b" />


## Summary
- Adds a sandbox mode toggle and sandbox webhook secret to the WooCommerce gateway settings
- Routes API requests to `/sandbox/api/v1/payment-links` when sandbox mode is enabled
- Selects the correct webhook secret (sandbox vs production) for signature validation
- Displays a warning admin notice when sandbox mode is active
- Adds 4 unit tests covering API path routing and webhook secret selection

## Test plan
- [ ] Enable the plugin, go to Settings > Payments > Coinbase Business and verify "Sandbox Mode" checkbox and "Sandbox Webhook Secret" field appear
- [ ] Enable sandbox mode — confirm the yellow admin notice appears on all admin pages
- [ ] Place a test order — verify the API request targets `/sandbox/api/v1/payment-links` (check debug log)
- [ ] Simulate a webhook with the sandbox secret — confirm signature validation succeeds
- [ ] Disable sandbox mode — confirm requests go to `/api/v1/payment-links` and the admin notice disappears
- [ ] Run `./vendor/bin/phpunit` and verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)