### PR TITLE
chore: Clarify API settings link and ECDSA key wording in docs/settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ Description of the payment method on the checkout page
 
 ### CDP API Key Name
 
-Your CDP API key name from the [Coinbase Business dashboard].
+Your CDP API key name from the [Coinbase Business Account API settings].
 
 ### CDP API Private Key
 
-Your EC private key in PEM format. Paste the full key including BEGIN/END lines.
+Your ECDSA private key in PEM format. Paste the full key including BEGIN/END lines.
 
 ### Webhook Secret
 
-Your webhook secret from the [Coinbase Business dashboard].
+Your webhook secret from the [Coinbase Business Account API settings].
 
 Using webhooks allows Coinbase Business to send payment confirmation messages to the website. To fill this out:
 
@@ -153,7 +153,7 @@ This project is licensed under the Apache 2.0 License
 
 [//]: # "Comments for storing reference material in. Stripped out when processing the markdown"
 [Coinbase Business]: https://coinbase.com/business
-[Coinbase Business dashboard]: https://coinbase.com/business
+[Coinbase Business Account API settings]: https://www.coinbase.com/settings/api
 [WooCommerce]: https://woocommerce.com/
 [WordPress]: https://wordpress.org/
 [WordPress.org plugin repository]: https://wordpress.org/plugins/coinbase-commerce/

--- a/class-wc-gateway-coinbase.php
+++ b/class-wc-gateway-coinbase.php
@@ -157,7 +157,7 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 				'title'       => __( 'CDP API Private Key', 'coinbase' ),
 				'type'        => 'textarea',
 				'default'     => '',
-				'description' => __( 'Your EC private key in PEM format. Paste the full key including BEGIN/END lines.', 'coinbase' ),
+				'description' => __( 'Your ECDSA private key in PEM format. Paste the full key including BEGIN/END lines.', 'coinbase' ),
 				'css'         => 'font-family: monospace; height: 150px;',
 			),
 			'webhook_secret'  => array(

--- a/includes/class-coinbase-jwt-auth.php
+++ b/includes/class-coinbase-jwt-auth.php
@@ -21,13 +21,13 @@ class Coinbase_JWT_Auth {
 	private $key_name;
 
 	/**
-	 * @var string EC private key in PEM format.
+	 * @var string ECDSA private key in PEM format.
 	 */
 	private $private_key;
 
 	/**
 	 * @param string $key_name       CDP API key name.
-	 * @param string $private_key_pem EC private key in PEM format.
+	 * @param string $private_key_pem ECDSA private key in PEM format.
 	 */
 	public function __construct( $key_name, $private_key_pem ) {
 		$this->key_name    = $key_name;

--- a/readme.txt
+++ b/readme.txt
@@ -59,7 +59,7 @@ Your CDP API key name from the Coinbase Business dashboard at https://coinbase.c
 
 = CDP API Private Key =
 
-Your EC private key in PEM format. Paste the full key including BEGIN/END lines.
+Your ECDSA private key in PEM format. Paste the full key including BEGIN/END lines.
 
 = Webhook Secret =
 


### PR DESCRIPTION
- Point the API key/webhook secret references to the Coinbase Business Account API settings page (coinbase.com/settings/api)
- Use "ECDSA private key" instead of "EC private key" in the settings field, README, readme.txt, and JWT auth docblocks

